### PR TITLE
Improve the CI caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Cargo Cache
-        uses: actions/cache@v2
+      - name: Install Rust stable
+        uses: actions-rs/toolchain@v1
         with:
-          path: |
-            target
-            ~/.cargo
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          toolchain: stable
+          override: true
+      - name: Cargo Cache
+        uses: Swatinem/rust-cache@v1
       - name: Build and test
         run: |
           cargo clippy --all-targets --all-features --  -D warnings


### PR DESCRIPTION
Using `actions/cache` leads to increasingly long downloading/uploading
times, as there is no mechanism to prune unused dependencies. Larger
projects, such as `tokio` and `rust-analyzer` - to name but a few, use
`Swatinem/rust-cache`, which implements smart caching for rust/cargo
projects with sensible defaults, so that's what we'll use too.