### PR TITLE
Skip redundant poll_max_time check when batch is already full

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -184,10 +184,8 @@ where
                                     // Flush if the batch is full.
                                     if this.lot.is_full() {
                                         this.state.set(State::flushing("size".to_owned(), None));
-                                    }
-
-                                    // Or flush if the max time has elapsed.
-                                    if this.lot.poll_max_time(cx).is_ready() {
+                                    } else if this.lot.poll_max_time(cx).is_ready() {
+                                        // Or flush if the max time has elapsed.
                                         this.state.set(State::flushing("time".to_owned(), None));
                                     }
                                 }


### PR DESCRIPTION
When is_full() triggers a flush, poll_max_time() was still called unnecessarily, registering a spurious waker and potentially overwriting the flush reason from "size" to "time" in trace output.